### PR TITLE
Update RISEkbmRasch Quarto template.qmd

### DIFF
--- a/Quarto/RISEkbmRasch Quarto template.qmd
+++ b/Quarto/RISEkbmRasch Quarto template.qmd
@@ -92,7 +92,8 @@ library(HH)
 library(glue)
 
 #---- Load data----
-df <- as.data.frame(read_excel("GNI23data v1.1.xls"))
+df <- as.data.frame(read_excel("GNI23data v1.1.xls")) %>%
+  mutate_at(vars(starts_with("WAAQ")), funs(str_replace(., "NULL", NA_character_) %>% as.numeric))
 
 ### if you need to download the datafile:
 # library(readODS)


### PR DESCRIPTION
At least on my machine (macos 13, RStudio 2022.12, R 4.2.1) the WAAQ columns are read as characters. This throws off things later such as NA exclusions and then analyses. Solved by doing conversion at read.